### PR TITLE
Added pymol_visualisation.py

### DIFF
--- a/hcie/Data/pymol_visualisation.py
+++ b/hcie/Data/pymol_visualisation.py
@@ -1,0 +1,35 @@
+"""
+This is a script for visualising the top returned bioisosteres from HCIE in their alignment of best similarity.
+It is written to be run in PyMol, and can be run as follows from the PyMol command line:
+
+run pymol_visualisation.py
+"""
+
+# First load in the HCIE alignments from the SDF
+cmd.load('overlay.sdf', multiplex=1)
+util.cbag('all')
+cmd.set('grid_mode', 1)
+
+# ShaEP outputs the aligned isosteres with the most similar last, so this needs to be reversed
+isosteres = cmd.get_object_list()
+isosteres = list(reversed(isosteres))
+
+for idx, isostere in enumerate(isosteres):
+    cmd.set('grid_slot', idx + 1, isostere)
+
+# Now set the view parameters
+cmd.show('sticks')
+cmd.set('ray_opaque_background', 'off')
+cmd.set('stick_radius', 0.1)
+cmd.show('spheres')
+cmd.set('sphere_scale', 0.15, 'all')
+cmd.set('sphere_scale', 0.12, 'elem H')
+cmd.color('gray40', 'elem C')
+cmd.set('sphere_quality', 30)
+cmd.set('stick_quality', 30)
+cmd.set('sphere_transparency', 0.0)
+cmd.set('stick_transparency', 0.0)
+cmd.set('ray_shadow', 'off')
+cmd.set('orthoscopic', 1)
+cmd.set('antialias', 2)
+cmd.bg_color('white')

--- a/hcie/molecule.py
+++ b/hcie/molecule.py
@@ -4,6 +4,7 @@ Contains functionality for Molecule class - inherits from RDKit Molecule class i
 from hcie.mol2_dict import bond_types, atom_types, NO_SUBSTRUCTS, MOLECULE_TYPE
 from rdkit import Chem
 import os
+import shutil
 import json
 import csv
 import autode
@@ -13,6 +14,8 @@ import xyz2mol
 
 # Set path to package data files referenced within the code
 VEHICLE_MOL2_FILENAME = pkg_resources.resource_filename("hcie", "Data/vehicle_dft.mol2")
+PYMOL_VISUALISATION = pkg_resources.resource_filename('hcie', 'Data/pymol_visualisation.py')
+
 with open(pkg_resources.resource_filename("hcie", "Data/vehicle_smiles.json"), 'r') as smiles_dict:
     vehicle_smiles = json.load(smiles_dict)
 
@@ -605,5 +608,7 @@ class Molecule(Chem.Mol):
         self.search_shaep()
         self.get_scores_from_similarity_file()
         self.print_output_file()
+
+        shutil.copy(PYMOL_VISUALISATION, '.')
 
         return None


### PR DESCRIPTION
pymol_visualisation.py, a script to be run in PyMol to visualise neatly the outputs from HCIE. shaep method in molecule.py altered so that pymol_visualisation.py is copied into the directory with the HCIE results